### PR TITLE
Validate pangram designation requires all 7 day letters

### DIFF
--- a/server/src/test-word-updates.ts
+++ b/server/src/test-word-updates.ts
@@ -83,14 +83,18 @@ async function main() {
   });
   counted(updatedNotes.notes === 'updated note', 'Update notes via PATCH');
 
-  // is_pangram toggle
-  const pangram = await request(`/days/2098-01-01/words/${w1.id}`, {
+  // is_pangram toggle (must use a word that contains all 7 letters)
+  const cocktailWord = await request('/days/2098-01-01/words', {
+    method: 'POST',
+    body: JSON.stringify({ word: 'cocktail' }),
+  });
+  const pangram = await request(`/days/2098-01-01/words/${cocktailWord.id}`, {
     method: 'PATCH',
     body: JSON.stringify({ is_pangram: true }),
   });
-  counted(pangram.is_pangram === true, 'Set is_pangram to true');
+  counted(pangram.is_pangram === true, 'Set is_pangram to true on valid pangram');
 
-  const notPangram = await request(`/days/2098-01-01/words/${w1.id}`, {
+  const notPangram = await request(`/days/2098-01-01/words/${cocktailWord.id}`, {
     method: 'PATCH',
     body: JSON.stringify({ is_pangram: false }),
   });


### PR DESCRIPTION
## Summary
- A word marked as pangram must contain every letter from the day's puzzle, which inherently enforces the 7-character minimum
- Validation added to both POST (create) and PATCH (update) word endpoints
- Returns 400 with descriptive error listing missing letters

## Test plan
- [x] Short word (4 letters) rejected as pangram on POST
- [x] Word missing day letters rejected as pangram on POST
- [x] Valid pangram (COCKTAIL) accepted on POST
- [x] Short word rejected as pangram on PATCH
- [x] All 30 seed-test assertions pass
- [x] All 37 error-handling assertions pass (5 new)
- [x] All 27 word-update assertions pass (test updated to use valid pangram)

Fixes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)