### PR TITLE
Resolve DB path relative to __dirname instead of process.cwd()

### DIFF
--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -2,7 +2,10 @@ import Database from 'better-sqlite3';
 import fs from 'fs';
 import path from 'path';
 
-const DB_PATH = process.env.DB_PATH || path.join(process.cwd(), 'data', 'spelling-bee.db');
+// Resolve relative to project root (two levels up from server/src/), not process.cwd(),
+// so the DB location is the same regardless of how the server is started.
+const PROJECT_ROOT = path.resolve(__dirname, '..', '..');
+const DB_PATH = process.env.DB_PATH || path.join(PROJECT_ROOT, 'data', 'spelling-bee.db');
 
 let db: Database.Database | null = null;
 


### PR DESCRIPTION
## Summary
- Changed `db.ts` to resolve the database path relative to `__dirname` (project root) instead of `process.cwd()`
- `process.cwd()` returned `server/` when run via npm workspaces, placing the DB at `server/data/` — making the documented cleanup path (`rm -rf data/`) ineffective
- DB now consistently lives at `data/spelling-bee.db` at the project root

## Test plan
- [x] Server starts and creates DB at `data/` (project root)
- [x] `server/data/` is not created
- [x] `rm -rf data/ && npm run dev` produces a fresh empty database
- [x] All 30 seed-test assertions pass
- [x] TypeScript compiles cleanly

Fixes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)