### PR TITLE
Add npm run test:fresh for automated test runs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,14 +43,21 @@ npx tsc --noEmit -p client/tsconfig.json  # Type-check client
 
 ### Running Tests
 
-The verification suite requires a running server with a fresh database:
+Run all test suites automatically (each gets a fresh database):
+
+```bash
+npm run test:fresh               # Run all test suites
+./scripts/test-fresh.sh server/src/seed-test.ts  # Run a single suite
+```
+
+Or manually with two terminals:
 
 ```bash
 rm -rf data/ && npm run dev    # Terminal 1: clean DB + start servers
 npx tsx server/src/seed-test.ts  # Terminal 2: run test suite
 ```
 
-All 30 assertions must pass before any branch is considered merge-ready.
+All assertions must pass before any branch is considered merge-ready.
 
 ## Git Workflow
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "dev": "concurrently -n server,client -c blue,green \"npm run dev -w server\" \"npm run dev -w client\"",
     "build": "npm run build -w client && npm run build -w server",
-    "start": "npm run start -w server"
+    "start": "npm run start -w server",
+    "test:fresh": "./scripts/test-fresh.sh"
   },
   "devDependencies": {
     "concurrently": "^9.1.0"

--- a/scripts/test-fresh.sh
+++ b/scripts/test-fresh.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Run test suites against a fresh database.
+# Usage: ./scripts/test-fresh.sh [test-file...]
+# If no test files specified, runs all test suites.
+
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DB_DIR="$PROJECT_ROOT/data"
+PORT=3141
+SERVER_PID=""
+
+cleanup() {
+  if [ -n "$SERVER_PID" ]; then
+    kill "$SERVER_PID" 2>/dev/null || true
+    wait "$SERVER_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+kill_port() {
+  local pids
+  pids=$(lsof -ti:"$PORT" 2>/dev/null || true)
+  if [ -n "$pids" ]; then
+    echo "$pids" | xargs kill -9 2>/dev/null || true
+    sleep 1
+  fi
+}
+
+start_server() {
+  rm -rf "$DB_DIR"
+  npx tsx "$PROJECT_ROOT/server/src/index.ts" &
+  SERVER_PID=$!
+
+  # Poll health endpoint until ready (max 10 seconds)
+  local attempts=0
+  while ! curl -sf "http://localhost:$PORT/api/health" >/dev/null 2>&1; do
+    attempts=$((attempts + 1))
+    if [ $attempts -ge 20 ]; then
+      echo "FAIL: Server did not start within 10 seconds"
+      exit 1
+    fi
+    sleep 0.5
+  done
+}
+
+stop_server() {
+  if [ -n "$SERVER_PID" ]; then
+    kill "$SERVER_PID" 2>/dev/null || true
+    wait "$SERVER_PID" 2>/dev/null || true
+    SERVER_PID=""
+  fi
+}
+
+# Default test suites in run order
+DEFAULT_SUITES=(
+  "server/src/seed-test.ts"
+  "server/src/test-error-handling.ts"
+  "server/src/test-word-updates.ts"
+  "server/src/test-cascade-and-list.ts"
+  "server/src/test-backfill-edges.ts"
+  "server/src/test-attempts-and-export.ts"
+)
+
+# Use provided files or defaults
+if [ $# -gt 0 ]; then
+  SUITES=("$@")
+else
+  SUITES=("${DEFAULT_SUITES[@]}")
+fi
+
+echo "=== Test Runner ==="
+echo ""
+
+kill_port
+
+passed=0
+failed=0
+
+for suite in "${SUITES[@]}"; do
+  suite_path="$PROJECT_ROOT/$suite"
+  if [ ! -f "$suite_path" ]; then
+    echo "SKIP: $suite (file not found)"
+    continue
+  fi
+
+  echo "--- Running: $suite ---"
+  kill_port
+  start_server
+
+  if npx tsx "$suite_path"; then
+    passed=$((passed + 1))
+  else
+    failed=$((failed + 1))
+    echo "FAIL: $suite"
+  fi
+
+  stop_server
+  echo ""
+done
+
+echo "=== Results: $passed passed, $failed failed ==="
+
+if [ $failed -gt 0 ]; then
+  exit 1
+fi

--- a/server/src/test-cascade-and-list.ts
+++ b/server/src/test-cascade-and-list.ts
@@ -28,7 +28,7 @@ async function main() {
 
   await request('/days', {
     method: 'POST',
-    body: JSON.stringify({ date: '2097-03-01', letters: ['A', 'B', 'C', 'D', 'E', 'F', 'G'] }),
+    body: JSON.stringify({ date: '2097-03-01', letters: ['T', 'I', 'A', 'O', 'L', 'K', 'C'] }),
   });
   await request('/days', {
     method: 'POST',
@@ -53,11 +53,11 @@ async function main() {
   // Add words to verify counts
   await request('/days/2097-03-01/words', {
     method: 'POST',
-    body: JSON.stringify({ word: 'ace' }),
+    body: JSON.stringify({ word: 'tick' }),
   });
   await request('/days/2097-03-01/words', {
     method: 'POST',
-    body: JSON.stringify({ word: 'badge', is_pangram: true }),
+    body: JSON.stringify({ word: 'cocktail', is_pangram: true }),
   });
 
   const listWithWords = await request('/days');


### PR DESCRIPTION
## Summary
- Adds `scripts/test-fresh.sh` and `npm run test:fresh` to automate the full test cycle
- Each suite gets a fresh server + database: kill port → rm DB → start server → poll health → run suite → stop
- Supports running specific suites: `./scripts/test-fresh.sh server/src/seed-test.ts`
- Fixes `test-cascade-and-list.ts` which used invalid pangram data (exposed by #2 fix)
- Updates CLAUDE.md to document the new script

## Test plan
- [x] `npm run test:fresh` runs all 6 suites (157 assertions), all pass
- [x] `./scripts/test-fresh.sh server/src/seed-test.ts` runs a single suite
- [x] Server is cleaned up after script completes (no zombie processes)
- [x] TypeScript compiles cleanly

Fixes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)