### PR TITLE
Add predev port cleanup and kill-others-on-fail to concurrently

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "client"
   ],
   "scripts": {
-    "dev": "concurrently -n server,client -c blue,green \"npm run dev -w server\" \"npm run dev -w client\"",
+    "predev": "lsof -ti:3141 | xargs kill -9 2>/dev/null || true",
+    "dev": "concurrently --kill-others-on-fail -n server,client -c blue,green \"npm run dev -w server\" \"npm run dev -w client\"",
     "build": "npm run build -w client && npm run build -w server",
     "start": "npm run start -w server",
     "test:fresh": "./scripts/test-fresh.sh"


### PR DESCRIPTION
## Summary
- Adds `predev` script that kills any existing process on port 3141 before starting, preventing `EADDRINUSE` errors
- Adds `--kill-others-on-fail` flag to `concurrently` so if either `tsx watch` or `vite` crashes, the other is terminated instead of left as a zombie process

## Test plan
- [x] Running `npm run dev` twice in a row works without port conflicts
- [x] All 6 test suites pass (157 assertions)

Fixes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)