### PR TITLE
Change word click from pangram marking to inspire mode

### DIFF
--- a/client/src/components/NewDiscoveryMode.tsx
+++ b/client/src/components/NewDiscoveryMode.tsx
@@ -210,7 +210,14 @@ export function NewDiscoveryMode({ day, words, onWordsChange }: Props) {
           Full word list ({words.length} words)
         </summary>
         <div className="mt-2">
-          <WordList words={words} pulsingId={pulsingId} />
+          <WordList
+            words={words}
+            pulsingId={pulsingId}
+            onWordClick={(word) => {
+              setInspireSource(word);
+              setInspireMode(true);
+            }}
+          />
         </div>
       </details>
     </div>

--- a/client/src/components/PrePangramMode.tsx
+++ b/client/src/components/PrePangramMode.tsx
@@ -14,12 +14,33 @@ interface Props {
 export function PrePangramMode({ day, words, onWordsChange, onDayChange }: Props) {
   const [pulsingId, setPulsingId] = useState<number | null>(null);
   const [pangramCandidate, setPangramCandidate] = useState<Word | null>(null);
+  const [inspireMode, setInspireMode] = useState(false);
+  const [inspireSource, setInspireSource] = useState<Word | null>(null);
 
   async function handleAddWord(word: string) {
     try {
+      if (inspireMode && inspireSource) {
+        const result = await api.inspireWord(day.date, inspireSource.id, {
+          word,
+          status: 'pending',
+          inspiration_confidence: 'certain',
+        });
+        if (result.is_reattempt) {
+          showToast(`${result.word} — already entered (×${result.attempt_count})`, 'warning');
+          setPulsingId(result.id);
+          setTimeout(() => setPulsingId(null), 2000);
+        } else {
+          showToast(`${result.word} (inspired by ${inspireSource.word})`, 'info');
+        }
+        setInspireMode(false);
+        setInspireSource(null);
+        onWordsChange();
+        return;
+      }
+
       const result = await api.addWord(day.date, { word, stage: 'pre-pangram' });
       if (result.is_reattempt) {
-        showToast(`${result.word} — already entered (\u00d7${result.attempt_count})`, 'warning');
+        showToast(`${result.word} — already entered (×${result.attempt_count})`, 'warning');
         setPulsingId(result.id);
         setTimeout(() => setPulsingId(null), 2000);
         onWordsChange();
@@ -80,11 +101,24 @@ export function PrePangramMode({ day, words, onWordsChange, onDayChange }: Props
         <span data-testid="word-count" className="text-sm text-gray-500">{words.length} words</span>
       </div>
 
+      {inspireMode && inspireSource && (
+        <div className="bg-purple-50 border border-purple-200 rounded-lg px-3 py-2 text-sm text-purple-700 flex items-center justify-between">
+          <span>Adding word inspired by <strong>{inspireSource.word}</strong></span>
+          <button onClick={() => { setInspireMode(false); setInspireSource(null); }} className="text-purple-500 hover:text-purple-700">
+            Cancel
+          </button>
+        </div>
+      )}
+
       <WordInput
         onSubmit={handleAddWord}
         letters={day.letters}
         centerLetter={day.center_letter}
-        placeholder="Brainstorm words... (Enter to add)"
+        placeholder={
+          inspireMode && inspireSource
+            ? `Inspired by ${inspireSource.word}...`
+            : 'Brainstorm words... (Enter to add)'
+        }
         disabled={!!pangramCandidate}
       />
 
@@ -112,18 +146,15 @@ export function PrePangramMode({ day, words, onWordsChange, onDayChange }: Props
       )}
 
       <div className="text-xs text-gray-500">
-        Click a word to mark it as pangram, or press <kbd className="px-1 bg-gray-100 border rounded">P</kbd> for the last word
+        Click a word to add an inspired word, or press <kbd className="px-1 bg-gray-100 border rounded">P</kbd> to mark the last word as pangram
       </div>
 
       <WordList
         words={words}
         pulsingId={pulsingId}
         onWordClick={(word) => {
-          if (isPangramCandidate(word.word)) {
-            handleMarkPangram(word);
-          } else {
-            showToast(`${word.word} doesn't use all 7 letters — not a pangram`, 'warning');
-          }
+          setInspireSource(word);
+          setInspireMode(true);
         }}
       />
     </div>


### PR DESCRIPTION
## Summary
- In PrePangramMode, clicking a word now activates inspire mode (sets the word as inspiration source) instead of trying to mark it as a pangram
- In NewDiscoveryMode, the full word list (inside the `<details>` dropdown) is now clickable to set an inspiration source
- The `P` keyboard shortcut remains the way to mark pangrams; hint text updated accordingly

## Test plan
- [x] `npx tsc --noEmit` passes for client
- [x] `npm run build -w client` succeeds
- [x] `npm run test:fresh` — all 8 suites pass
- [ ] Manual: in pre-pangram mode, click a word → verify purple inspire banner appears and input placeholder changes
- [ ] Manual: enter a word while inspire mode is active → verify it's linked as inspired
- [ ] Manual: click Cancel on the inspire banner → verify mode deactivates

Closes #18